### PR TITLE
로비, 게임 룸(Room) 기능 버그 수정

### DIFF
--- a/src/main/java/ajou/mse/dimensionguard/BackendApplication.java
+++ b/src/main/java/ajou/mse/dimensionguard/BackendApplication.java
@@ -2,7 +2,9 @@ package ajou.mse.dimensionguard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/ajou/mse/dimensionguard/controller/RoomController.java
+++ b/src/main/java/ajou/mse/dimensionguard/controller/RoomController.java
@@ -5,7 +5,7 @@ import ajou.mse.dimensionguard.dto.room.RoomDto;
 import ajou.mse.dimensionguard.dto.room.response.GameStartResponse;
 import ajou.mse.dimensionguard.dto.room.response.RoomResponse;
 import ajou.mse.dimensionguard.security.UserPrincipal;
-import ajou.mse.dimensionguard.service.GameSyncService;
+import ajou.mse.dimensionguard.gameService.GameSyncService;
 import ajou.mse.dimensionguard.service.RoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/ajou/mse/dimensionguard/domain/BaseTimeEntity.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/BaseTimeEntity.java
@@ -1,0 +1,30 @@
+package ajou.mse.dimensionguard.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime updatedAt;
+}

--- a/src/main/java/ajou/mse/dimensionguard/domain/Member.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/Member.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ajou/mse/dimensionguard/domain/Room.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/Room.java
@@ -12,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-public class Room {
+public class Room extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Player.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Player.java
@@ -1,5 +1,6 @@
 package ajou.mse.dimensionguard.domain.player;
 
+import ajou.mse.dimensionguard.domain.BaseTimeEntity;
 import ajou.mse.dimensionguard.domain.Member;
 import ajou.mse.dimensionguard.domain.Room;
 import lombok.AccessLevel;
@@ -14,7 +15,7 @@ import javax.persistence.*;
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "type")
 @Entity
-public abstract class Player {
+public abstract class Player extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ajou/mse/dimensionguard/exception/player/PlayerByMemberAndRoomNotFoundException.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/player/PlayerByMemberAndRoomNotFoundException.java
@@ -1,0 +1,10 @@
+package ajou.mse.dimensionguard.exception.player;
+
+import ajou.mse.dimensionguard.exception.common.NotFoundException;
+
+public class PlayerByMemberAndRoomNotFoundException extends NotFoundException {
+    
+    public PlayerByMemberAndRoomNotFoundException(Integer memberId, Integer roomId) {
+        super("memberId=" + memberId + ", roomId=" + roomId);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/exception/player/PlayerByMemberIdNotFoundException.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/player/PlayerByMemberIdNotFoundException.java
@@ -1,9 +1,0 @@
-package ajou.mse.dimensionguard.exception.player;
-
-import ajou.mse.dimensionguard.exception.common.NotFoundException;
-
-public class PlayerByMemberIdNotFoundException extends NotFoundException {
-    public PlayerByMemberIdNotFoundException(Integer memberId) {
-        super("memberId=" + memberId);
-    }
-}

--- a/src/main/java/ajou/mse/dimensionguard/gameService/GameSyncService.java
+++ b/src/main/java/ajou/mse/dimensionguard/gameService/GameSyncService.java
@@ -1,9 +1,11 @@
-package ajou.mse.dimensionguard.service;
+package ajou.mse.dimensionguard.gameService;
 
 import ajou.mse.dimensionguard.domain.Room;
 import ajou.mse.dimensionguard.domain.player.Player;
 import ajou.mse.dimensionguard.exception.room.EveryoneNotReadyException;
 import ajou.mse.dimensionguard.exception.room.GameStartException;
+import ajou.mse.dimensionguard.service.PlayerService;
+import ajou.mse.dimensionguard.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
@@ -38,9 +40,6 @@ public class GameSyncService {
     private boolean checkDeliveredToEveryone(Room room) {
         entityManager.clear();
         List<Player> players = playerService.findAllEntityByRoom(room);
-        players.forEach(player -> {
-            System.out.println("player[" + player.getMember().getAccountId() + "].ready = " + player.getIsReady());
-        });
         return players.stream().allMatch(Player::getIsReady);
     }
 }

--- a/src/main/java/ajou/mse/dimensionguard/repository/PlayerRepository.java
+++ b/src/main/java/ajou/mse/dimensionguard/repository/PlayerRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public interface PlayerRepository extends JpaRepository<Player, Integer> {
 
     @EntityGraph(attributePaths = {"member", "room"})
-    Optional<Player> findByMember_Id(Integer memberId);
+    Optional<Player> findByMember_IdAndRoom_Id(Integer memberId, Integer roomId);
 
     @EntityGraph(attributePaths = {"member", "room"})
     List<Player> findAllByRoom(Room room);

--- a/src/main/java/ajou/mse/dimensionguard/service/PlayerService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/PlayerService.java
@@ -2,7 +2,7 @@ package ajou.mse.dimensionguard.service;
 
 import ajou.mse.dimensionguard.domain.Room;
 import ajou.mse.dimensionguard.domain.player.Player;
-import ajou.mse.dimensionguard.exception.player.PlayerByMemberIdNotFoundException;
+import ajou.mse.dimensionguard.exception.player.PlayerByMemberAndRoomNotFoundException;
 import ajou.mse.dimensionguard.repository.PlayerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,9 +22,9 @@ public class PlayerService {
         return playerRepository.save(player);
     }
 
-    public Player findEntityByMemberId(Integer memberId) {
-        return playerRepository.findByMember_Id(memberId)
-                .orElseThrow(() -> new PlayerByMemberIdNotFoundException(memberId));
+    public Player findEntityByMemberIdAndRoomId(Integer memberId, Integer roomId) {
+        return playerRepository.findByMember_IdAndRoom_Id(memberId, roomId)
+                .orElseThrow(() -> new PlayerByMemberAndRoomNotFoundException(memberId, roomId));
     }
 
     public List<Player> findAllEntityByRoom(Room room) {

--- a/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
@@ -38,10 +38,9 @@ public class RoomService {
         Room room = this.findEntityById(roomId);
         Member member = memberService.findEntityById(loginMemberId);
 
-        Player player = playerService.save(Hero.of(member, room));
-        room.getPlayers().add(player);
+        playerService.save(Hero.of(member, room));
 
-        return RoomDto.from(room);
+        return RoomDto.from(room);  // players lazy loading
     }
 
     public Room findEntityById(Integer roomId) {

--- a/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
@@ -53,7 +53,7 @@ public class RoomService {
         Room room = this.findEntityById(roomId);
 
         if (room.getStatus() != RoomStatus.READY) {
-            Player player = playerService.findEntityByMemberId(loginMemberId);
+            Player player = playerService.findEntityByMemberIdAndRoomId(loginMemberId, roomId);
             player.setReady();
             return true;
         }
@@ -66,7 +66,7 @@ public class RoomService {
         Room room = this.findEntityById(roomId);
         room.start();
 
-        Player player = playerService.findEntityByMemberId(loginMemberId);
+        Player player = playerService.findEntityByMemberIdAndRoomId(loginMemberId, roomId);
         player.setReady();
 
         return RoomDto.from(room);


### PR DESCRIPTION
## 🔥 Related Issue
- Close #9

## 🏃‍ Task
- `BaseTimeEntity` 구현 및 각 entity에 `BaseTimeEntity` 추가
- 게임 룸 참가 시 응답 데이터에 일부 player 정보가 중복되는 버그 수정
- 특정 회원이 참가중인 게임 룸이 여러개인 경우 에러가 발생하는 버그 수정
- `GameSyncService`에 aop logging을 적용하지 않기 위해 package path 변경

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
