### PR TITLE
게임 시작 로직 변경

### DIFF
--- a/src/main/java/ajou/mse/dimensionguard/controller/RoomController.java
+++ b/src/main/java/ajou/mse/dimensionguard/controller/RoomController.java
@@ -96,13 +96,12 @@ public class RoomController {
     @GetMapping("/{roomId}/start")
 
     public GameStartResponse checkGameStarted(
-            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "PK of room",
                     example = "1"
             ) @PathVariable Integer roomId
     ) {
-        boolean isStarted = roomService.checkGameStarted(userPrincipal.getMemberId(), roomId);
+        boolean isStarted = roomService.checkGameStarted(roomId);
         return GameStartResponse.of(isStarted);
     }
 

--- a/src/main/java/ajou/mse/dimensionguard/controller/RoomController.java
+++ b/src/main/java/ajou/mse/dimensionguard/controller/RoomController.java
@@ -106,33 +106,33 @@ public class RoomController {
     }
 
     @Operation(
-            summary = "게임 시작",
-            description = "<p>게임을 시작합니다." +
-                    "<p>모든 플레이어의 통신 상태가 정상적일 경우(모든 플레이어에게 게임 시작 여부가 전달되었을 경우)에야 요청에 대한 응답을 처리합니다." +
-                    "<p>게임 시작 API 호출 후 10초 동안 모든 플레이어가 준비되지 않았다면 에러(2502)를 발생시킵니다.",
+            summary = "게임 준비",
+            description = "<p>게임 준비를 수행합니다." +
+                    "<p>대기실에 있는 player를 ready 상태로 변경합니다." +
+                    "<p>모든 플레이어가 ready 상태가 되었을 때 요청에 대한 응답을 반환합니다." +
+                    "<p>API 호출 후 15초 동안 모든 플레이어가 준비되기를 기다립니다.",
             security = @SecurityRequirement(name = "access-token")
     )
     @ApiResponses({
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = RoomResponse.class))),
             @ApiResponse(
                     description = "<p>[2501] 서버 내부 오류로 인해 thread sleep이 중단된 경우" +
-                            "<p>[2502] 참가자들 중 일부 인원이 준비되지 않은 경우. 주로 \"게임 시작 여부 확인\" API를 호출하지 않을 경우에 발생",
-                    responseCode = "500",
-                    content = @Content
+                            "<p>[2502] 게임 준비 API 호출 후 15초 동안 참가자 전원의 준비가 되지 않은 경우",
+                    responseCode = "500", content = @Content
             )
     })
-    @PatchMapping("/{roomId}/start")
-    public RoomResponse gameStart(
+    @PatchMapping("/{roomId}/ready")
+    public RoomResponse ready(
             @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "PK of room",
                     example = "1"
             ) @PathVariable Integer roomId
     ) {
-        RoomDto roomDto = roomService.gameStart(userPrincipal.getMemberId(), roomId);
+        RoomDto roomDto = roomService.ready(userPrincipal.getMemberId(), roomId);
 
         try {
-            gameSyncService.syncUntilDeliveredToEveryone(roomId);
+            gameSyncService.waitUntilEveryoneIsReady(roomId);
         } catch (Exception ex) {
             roomService.init(roomId);
             throw ex;

--- a/src/main/java/ajou/mse/dimensionguard/dto/player/response/PlayerCompactResponse.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/player/response/PlayerCompactResponse.java
@@ -1,7 +1,5 @@
 package ajou.mse.dimensionguard.dto.player.response;
 
-import ajou.mse.dimensionguard.domain.player.Position;
-import ajou.mse.dimensionguard.dto.member.response.MemberResponse;
 import ajou.mse.dimensionguard.dto.player.PlayerDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -15,24 +13,20 @@ public class PlayerCompactResponse {
     @Schema(description = "PK of player", example = "3")
     private Integer id;
 
-    @Schema(description = "회원 정보")
-    private MemberResponse memberDto;
-
-    @Schema(description = "참여중인 게임 룸의 PK", example = "2")
-    private Integer roomId;
+    @Schema(description = "PK of member", example = "1")
+    private Integer memberId;
 
     @Schema(description = "보스 여부", example = "false")
     private Boolean isBoss;
 
-    public static PlayerCompactResponse of(Integer id, MemberResponse memberDto, Integer roomId, Boolean isBoss) {
-        return new PlayerCompactResponse(id, memberDto, roomId, isBoss);
+    public static PlayerCompactResponse of(Integer id, Integer memberId, Boolean isBoss) {
+        return new PlayerCompactResponse(id, memberId, isBoss);
     }
 
     public static PlayerCompactResponse from(PlayerDto dto) {
         return of(
                 dto.getId(),
-                MemberResponse.from(dto.getMemberDto()),
-                dto.getRoomId(),
+                dto.getMemberDto().getId(),
                 dto.getIsBoss()
         );
     }

--- a/src/main/java/ajou/mse/dimensionguard/exception/ExceptionType.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/ExceptionType.java
@@ -3,11 +3,13 @@ package ajou.mse.dimensionguard.exception;
 import ajou.mse.dimensionguard.constant.exception.ValidationErrorCode;
 import ajou.mse.dimensionguard.domain.Member;
 import ajou.mse.dimensionguard.domain.Room;
+import ajou.mse.dimensionguard.domain.player.Player;
 import ajou.mse.dimensionguard.exception.auth.AccountIdNotFoundException;
 import ajou.mse.dimensionguard.exception.auth.PasswordNotValidException;
 import ajou.mse.dimensionguard.exception.auth.TokenValidateException;
 import ajou.mse.dimensionguard.exception.member.AccountIdDuplicateException;
 import ajou.mse.dimensionguard.exception.member.MemberIdNotFoundException;
+import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberAndRoomException;
 import ajou.mse.dimensionguard.exception.room.EveryoneNotReadyException;
 import ajou.mse.dimensionguard.exception.room.GameStartException;
 import ajou.mse.dimensionguard.exception.room.RoomIdNotFoundException;
@@ -45,6 +47,7 @@ import java.util.Optional;
  *     <li>15XX: 인증 관련 예외</li>
  *     <li>2000 ~ 2499: 회원({@link Member}) 관련 예외</li>
  *     <li>2500 ~ 2999: 게임 룸({@link Room}) 관련 예외</li>
+ *     <li>3000 ~ 3399: 플레이어({@link Player}) 관련 예외</li>
  * </ul>
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -105,6 +108,11 @@ public enum ExceptionType {
     ROOM_ID_NOT_FOUND(2500, "게임 룸을 찾을 수 없습니다.", RoomIdNotFoundException.class),
     GAME_START(2501, "알 수 없는 이유로 게임을 시작할 수 없습니다.", GameStartException.class),
     EVERYONE_NOT_READY(2502, "참가자들의 준비를 기다렸으나, 참가자 전원의 준비가 되지 않았습니다.", EveryoneNotReadyException.class),
+
+    /**
+     * 플레이어({@link Player}) 관련 예외
+     */
+    PLAYER_NOT_FOUND_BY_MEMBER_AND_ROOM(3000, "플레이어를 찾을 수 없습니다.", PlayerNotFoundByMemberAndRoomException.class)
     ;
 
     private final Integer code;

--- a/src/main/java/ajou/mse/dimensionguard/exception/ExceptionType.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/ExceptionType.java
@@ -104,7 +104,7 @@ public enum ExceptionType {
      */
     ROOM_ID_NOT_FOUND(2500, "게임 룸을 찾을 수 없습니다.", RoomIdNotFoundException.class),
     GAME_START(2501, "알 수 없는 이유로 게임을 시작할 수 없습니다.", GameStartException.class),
-    EVERYONE_NOT_READY(2502, "참가자 전원의 준비가 되지 않았습니다. 네트워크 문제일 수 있습니다.", EveryoneNotReadyException.class),
+    EVERYONE_NOT_READY(2502, "참가자들의 준비를 기다렸으나, 참가자 전원의 준비가 되지 않았습니다.", EveryoneNotReadyException.class),
     ;
 
     private final Integer code;

--- a/src/main/java/ajou/mse/dimensionguard/exception/player/PlayerNotFoundByMemberAndRoomException.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/player/PlayerNotFoundByMemberAndRoomException.java
@@ -2,9 +2,9 @@ package ajou.mse.dimensionguard.exception.player;
 
 import ajou.mse.dimensionguard.exception.common.NotFoundException;
 
-public class PlayerByMemberAndRoomNotFoundException extends NotFoundException {
+public class PlayerNotFoundByMemberAndRoomException extends NotFoundException {
     
-    public PlayerByMemberAndRoomNotFoundException(Integer memberId, Integer roomId) {
+    public PlayerNotFoundByMemberAndRoomException(Integer memberId, Integer roomId) {
         super("memberId=" + memberId + ", roomId=" + roomId);
     }
 }

--- a/src/main/java/ajou/mse/dimensionguard/gameService/GameSyncService.java
+++ b/src/main/java/ajou/mse/dimensionguard/gameService/GameSyncService.java
@@ -23,21 +23,23 @@ public class GameSyncService {
     private final PlayerService playerService;
     private final EntityManager entityManager;
 
-    public void syncUntilDeliveredToEveryone(Integer roomId) {
+    public void waitUntilEveryoneIsReady(Integer roomId) {
         Room room = roomService.findEntityById(roomId);
 
         int count = 0;
         try {
-            while (!checkDeliveredToEveryone(room)) {
-                if (count++ >= 25) throw new EveryoneNotReadyException();
-                Thread.sleep(400);
+            while (!checkEveryoneIsReady(room)) {
+                if (++count > 30) {
+                    throw new EveryoneNotReadyException();
+                }
+                Thread.sleep(500);
             }
         } catch (InterruptedException ex) {
             throw new GameStartException(ex);
         }
     }
 
-    private boolean checkDeliveredToEveryone(Room room) {
+    private boolean checkEveryoneIsReady(Room room) {
         entityManager.clear();
         List<Player> players = playerService.findAllEntityByRoom(room);
         return players.stream().allMatch(Player::getIsReady);

--- a/src/main/java/ajou/mse/dimensionguard/service/PlayerService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/PlayerService.java
@@ -2,7 +2,7 @@ package ajou.mse.dimensionguard.service;
 
 import ajou.mse.dimensionguard.domain.Room;
 import ajou.mse.dimensionguard.domain.player.Player;
-import ajou.mse.dimensionguard.exception.player.PlayerByMemberAndRoomNotFoundException;
+import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberAndRoomException;
 import ajou.mse.dimensionguard.repository.PlayerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,7 +24,7 @@ public class PlayerService {
 
     public Player findEntityByMemberIdAndRoomId(Integer memberId, Integer roomId) {
         return playerRepository.findByMember_IdAndRoom_Id(memberId, roomId)
-                .orElseThrow(() -> new PlayerByMemberAndRoomNotFoundException(memberId, roomId));
+                .orElseThrow(() -> new PlayerNotFoundByMemberAndRoomException(memberId, roomId));
     }
 
     public List<Player> findAllEntityByRoom(Room room) {

--- a/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
@@ -63,9 +63,11 @@ public class RoomService {
     }
 
     @Transactional
-    public RoomDto gameStart(Integer loginMemberId, Integer roomId) {
+    public RoomDto ready(Integer loginMemberId, Integer roomId) {
         Room room = this.findEntityById(roomId);
-        room.start();
+        if (room.getStatus() == RoomStatus.READY) {
+            room.start();
+        }
 
         Player player = playerService.findEntityByMemberIdAndRoomId(loginMemberId, roomId);
         player.setReady();

--- a/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
@@ -57,16 +57,9 @@ public class RoomService {
     }
 
     @Transactional
-    public boolean checkGameStarted(Integer loginMemberId, Integer roomId) {
+    public boolean checkGameStarted(Integer roomId) {
         Room room = this.findEntityById(roomId);
-
-        if (room.getStatus() != RoomStatus.READY) {
-            Player player = playerService.findEntityByMemberIdAndRoomId(loginMemberId, roomId);
-            player.setReady();
-            return true;
-        }
-
-        return false;
+        return room.getStatus() != RoomStatus.READY;
     }
 
     @Transactional


### PR DESCRIPTION
## 🔥 Related Issue
- Close #15

## 🏃‍ Task
-  "게임 시작 여부 확인" API에서 player의 ready 상태를 변경하지 않도록 로직 제거.
- "게임 시작" API를 "게임 준비" API로 변경 및 적절하게 로직 변경

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
