### PR TITLE
한 명의 회원은 동시에 한 개의 게임 방에만 있을 수 있도록 예외처리 로직 추가

### DIFF
--- a/src/main/java/ajou/mse/dimensionguard/controller/RoomController.java
+++ b/src/main/java/ajou/mse/dimensionguard/controller/RoomController.java
@@ -40,6 +40,10 @@ public class RoomController {
                     "<p>생성한 호스트는 boss player가 됩니다.",
             security = @SecurityRequirement(name = "access-token")
     )
+    @ApiResponses({
+            @ApiResponse(description = "Created", responseCode = "201", content = @Content(schema = @Schema(implementation = RoomResponseWithPlayerStatus.class))),
+            @ApiResponse(description = "[2503] 이미 다른 방에 참여중이므로 참여중인 방에서 나간 후 재시도가 필요한 경우", responseCode = "409", content = @Content)
+    })
     @PostMapping
     public ResponseEntity<RoomResponseWithPlayerStatus> create(
             @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal
@@ -57,6 +61,10 @@ public class RoomController {
                     "<p>참가한 플레이어는 hero player가 됩니다.",
             security = @SecurityRequirement(name = "access-token")
     )
+    @ApiResponses({
+            @ApiResponse(description = "Created", responseCode = "201", content = @Content(schema = @Schema(implementation = RoomResponseWithPlayerStatus.class))),
+            @ApiResponse(description = "[2503] 이미 다른 방에 참여중이므로 참여중인 방에서 나간 후 재시도가 필요한 경우", responseCode = "409", content = @Content)
+    })
     @PostMapping("/{roomId}/join")
     public ResponseEntity<RoomResponseWithPlayerStatus> join(
             @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,

--- a/src/main/java/ajou/mse/dimensionguard/exception/ExceptionType.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/ExceptionType.java
@@ -11,6 +11,7 @@ import ajou.mse.dimensionguard.exception.member.AccountIdDuplicateException;
 import ajou.mse.dimensionguard.exception.member.MemberIdNotFoundException;
 import ajou.mse.dimensionguard.exception.member.MemberNameDuplicateException;
 import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberAndRoomException;
+import ajou.mse.dimensionguard.exception.room.AlreadyParticipatingException;
 import ajou.mse.dimensionguard.exception.room.EveryoneNotReadyException;
 import ajou.mse.dimensionguard.exception.room.GameStartException;
 import ajou.mse.dimensionguard.exception.room.RoomIdNotFoundException;
@@ -110,12 +111,12 @@ public enum ExceptionType {
     ROOM_ID_NOT_FOUND(2500, "게임 방을 찾을 수 없습니다. 해산되거나 게임이 시작된 방일 수 있습니다.", RoomIdNotFoundException.class),
     GAME_START(2501, "알 수 없는 이유로 게임을 시작할 수 없습니다.", GameStartException.class),
     EVERYONE_NOT_READY(2502, "참가자들의 준비를 기다렸으나, 참가자 전원의 준비가 되지 않았습니다.", EveryoneNotReadyException.class),
+    ALREADY_PARTICIPATING(2503, "이미 다른 방에 참여중입니다. 참여중인 방에서 나간 후 다시 시도해주세요.", AlreadyParticipatingException.class),
 
     /**
      * 플레이어({@link Player}) 관련 예외
      */
-    PLAYER_NOT_FOUND_BY_MEMBER_AND_ROOM(3000, "플레이어를 찾을 수 없습니다.", PlayerNotFoundByMemberAndRoomException.class)
-    ;
+    PLAYER_NOT_FOUND_BY_MEMBER_AND_ROOM(3000, "플레이어를 찾을 수 없습니다.", PlayerNotFoundByMemberAndRoomException.class);
 
     private final Integer code;
     private final String message;

--- a/src/main/java/ajou/mse/dimensionguard/exception/room/AlreadyParticipatingException.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/room/AlreadyParticipatingException.java
@@ -1,0 +1,10 @@
+package ajou.mse.dimensionguard.exception.room;
+
+import ajou.mse.dimensionguard.exception.common.ConflictException;
+
+public class AlreadyParticipatingException extends ConflictException {
+
+    public AlreadyParticipatingException(Integer participatingRoomId) {
+        super("참여중인 방의 id=" + participatingRoomId);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/repository/PlayerRepository.java
+++ b/src/main/java/ajou/mse/dimensionguard/repository/PlayerRepository.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 public interface PlayerRepository extends JpaRepository<Player, Integer> {
 
     @EntityGraph(attributePaths = {"member", "room"})
+    Optional<Player> findByMember_Id(Integer memberId);
+
+    @EntityGraph(attributePaths = {"member", "room"})
     Optional<Player> findByMember_IdAndRoom_Id(Integer memberId, Integer roomId);
 
     @EntityGraph(attributePaths = {"member", "room"})

--- a/src/main/java/ajou/mse/dimensionguard/service/PlayerService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/PlayerService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -20,6 +21,10 @@ public class PlayerService {
     @Transactional
     public Player save(Player player) {
         return playerRepository.save(player);
+    }
+
+    public Optional<Player> findOptEntityByMemberId(Integer memberId) {
+        return playerRepository.findByMember_Id(memberId);
     }
 
     public Player findEntityByMemberIdAndRoomId(Integer memberId, Integer roomId) {


### PR DESCRIPTION
## 🔥 Related Issue
- Close #12 

## 🏃‍ Task
- 한 명의 회원은 동시에 한 개의 게임 룸에만 있을 수 있도록 "방 생성", "방 참가" 시 확인 후 예외처리 로직 추가

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
