### PR TITLE
In-game 정보 갱신 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // Database - H2, MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.8'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10" // Querydsl
 }
 
 group = 'ajou.mse'
@@ -46,6 +53,10 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Querydsl
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+
     // Database - H2, MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
@@ -68,4 +79,20 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// Querydsl
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets { // IDE의 소스 폴더에 자동으로 넣어준다.
+    main.java.srcDir querydslDir
+}
+configurations {
+    querydsl.extendsFrom compileClasspath // 컴파일이 될때 같이 수행
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl // Q파일 생성
 }

--- a/src/main/java/ajou/mse/dimensionguard/config/QuerydslConfig.java
+++ b/src/main/java/ajou/mse/dimensionguard/config/QuerydslConfig.java
@@ -1,0 +1,16 @@
+package ajou.mse.dimensionguard.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/config/RedisConfig.java
+++ b/src/main/java/ajou/mse/dimensionguard/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package ajou.mse.dimensionguard.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    private final String redisHost;
+    private final int redisPort;
+
+    public RedisConfig(
+            @Value("${spring.redis.host}") String redisHost,
+            @Value("${spring.redis.port}") int redisPort
+    ) {
+        this.redisHost = redisHost;
+        this.redisPort = redisPort;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/constant/ConstantUtil.java
+++ b/src/main/java/ajou/mse/dimensionguard/constant/ConstantUtil.java
@@ -1,0 +1,29 @@
+package ajou.mse.dimensionguard.constant;
+
+import ajou.mse.dimensionguard.dto.redis.InGameRequestStatus;
+import ajou.mse.dimensionguard.dto.redis.SkillInfo;
+import ajou.mse.dimensionguard.service.GameSyncService;
+
+public class ConstantUtil {
+
+    /**
+     * <p>Sync 관련
+     * <p>{@link GameSyncService}
+     */
+    // Wait until everyone is ready. 최대 15sec.
+    public static final int WAITING_COUNT_FOR_READY = 30;
+    public static final int SLEEP_MILLIS_FOR_READY = 500;
+
+    // Wait until everyone request. 최대 0.7sec.
+    public static final int WAITING_COUNT_FOR_REQUEST = 24;
+    public static final int SLEEP_MILLIS_FOR_REQUEST = 25;
+
+    public static final int SLEEP_MILLIS_BEFORE_REQ_COUNT_RESET = 50;
+
+    /**
+     * <p>Redis time to live
+     * <p>{@link InGameRequestStatus}, {@link SkillInfo}
+     */
+    public static final int IN_GAME_REQUEST_STATUS_TIMEOUT = 2;
+    public static final int SKILL_INFO_TIMEOUT = 2;
+}

--- a/src/main/java/ajou/mse/dimensionguard/controller/InGameController.java
+++ b/src/main/java/ajou/mse/dimensionguard/controller/InGameController.java
@@ -1,0 +1,60 @@
+package ajou.mse.dimensionguard.controller;
+
+import ajou.mse.dimensionguard.constant.ConstantUtil;
+import ajou.mse.dimensionguard.dto.in_game.request.PlayerInGameRequest;
+import ajou.mse.dimensionguard.dto.in_game.response.InGameResponse;
+import ajou.mse.dimensionguard.security.UserPrincipal;
+import ajou.mse.dimensionguard.service.GameSyncService;
+import ajou.mse.dimensionguard.service.InGameService;
+import ajou.mse.dimensionguard.service.RoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static ajou.mse.dimensionguard.constant.ConstantUtil.SLEEP_MILLIS_BEFORE_REQ_COUNT_RESET;
+
+@Tag(name = "인게임 관련")
+@RequiredArgsConstructor
+@RequestMapping("/api/in-game")
+@RestController
+public class InGameController {
+
+    private final RoomService roomService;
+    private final InGameService inGameService;
+    private final GameSyncService gameSyncService;
+
+    @Operation(
+            summary = "인게임 데이터 갱신",
+            description = "",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @PostMapping
+    public InGameResponse update(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestBody PlayerInGameRequest inGameRequest
+    ) throws InterruptedException {
+        Integer loginMemberId = userPrincipal.getMemberId();
+
+        // 내 정보 update
+        inGameService.updateInGameData(loginMemberId, inGameRequest);
+
+        // sync 맞추기
+        Integer roomId = roomService.findEntityByMemberId(loginMemberId).getId();
+        gameSyncService.increaseRequestCount(roomId);
+        gameSyncService.waitUntilEveryoneRequest(roomId);
+        if (inGameRequest.getIsBoss()) {
+            Thread.sleep(SLEEP_MILLIS_BEFORE_REQ_COUNT_RESET);
+            gameSyncService.initRequestCount(roomId);
+        }
+
+        // 새롭게 갱신된 모든 player들의 정보 조회
+        return inGameService.getInGameData(roomId);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Boss.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Boss.java
@@ -34,6 +34,10 @@ public class Boss extends Player {
                 .build();
     }
 
+    public void decreaseHp(Integer damageDealt) {
+        this.setHp(this.getHp() - damageDealt);
+    }
+
     @Builder(access = AccessLevel.PROTECTED)
     private Boss(Integer id, Member member, Room room, Boolean isReady, Integer hp, Integer energy) {
         super(id, member, room, isReady, hp, energy);

--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Hero.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Hero.java
@@ -2,10 +2,7 @@ package ajou.mse.dimensionguard.domain.player;
 
 import ajou.mse.dimensionguard.domain.Member;
 import ajou.mse.dimensionguard.domain.Room;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Embedded;
@@ -20,11 +17,14 @@ public class Hero extends Player {
     public static final int HERO_MAX_HP = 10;
     public static final int HERO_MAX_ENERGY = 10;
 
+    @Setter(AccessLevel.PRIVATE)
     @Embedded
     private Position pos;
 
+    @Setter(AccessLevel.PRIVATE)
     private Integer damageDealt;
 
+    @Setter(AccessLevel.PRIVATE)
     private Integer motion;
 
     public static Hero of(Member member, Room room) {
@@ -43,6 +43,13 @@ public class Hero extends Player {
                 .damageDealt(damageDealt)
                 .motion(motion)
                 .build();
+    }
+
+    public void update(Integer hp, Integer energy, Position pos, Integer damageDealt, Integer motion) {
+        super.update(hp, energy);
+        this.setPos(pos);
+        this.setDamageDealt(damageDealt);
+        this.setMotion(motion);
     }
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Player.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Player.java
@@ -34,9 +34,11 @@ public abstract class Player extends BaseTimeEntity {
     @Column(nullable = false)
     private Boolean isReady;
 
+    @Setter(AccessLevel.PROTECTED)
     @Column(nullable = false)
     private Integer hp;
 
+    @Setter(AccessLevel.PRIVATE)
     @Column(nullable = false)
     private Integer energy;
 
@@ -46,6 +48,11 @@ public abstract class Player extends BaseTimeEntity {
 
     public void setNotReady() {
         this.setIsReady(false);
+    }
+
+    public void update(Integer hp, Integer energy) {
+        this.setHp(hp);
+        this.setEnergy(energy);
     }
 
     protected Player(Integer id, Member member, Room room, Boolean isReady, Integer hp, Integer energy) {

--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Position.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Position.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
+import javax.validation.constraints.NotNull;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -15,8 +16,10 @@ import javax.persistence.Embeddable;
 public class Position {
 
     @Schema(description = "x 좌표", example = "15")
+    @NotNull
     private Integer x;
 
     @Schema(description = "y 좌표", example = "30")
+    @NotNull
     private Integer y;
 }

--- a/src/main/java/ajou/mse/dimensionguard/dto/in_game/request/PlayerInGameRequest.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/in_game/request/PlayerInGameRequest.java
@@ -1,0 +1,44 @@
+package ajou.mse.dimensionguard.dto.in_game.request;
+
+import ajou.mse.dimensionguard.domain.player.Position;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class PlayerInGameRequest {
+
+    @Schema(description = "보스인지 여부", example = "false")
+    @NotNull
+    private Boolean isBoss;
+
+    @Schema(description = "체력", example = "100")
+    @NotNull
+    private Integer hp;
+
+    @Schema(description = "에너지", example = "50")
+    @NotNull
+    private Integer energy;
+
+    // For hero
+    @Schema(description = "<p>현재 위치 (for hero)" +
+            "<p>해당하지 않는 경우(boss인 경우) <code>null</code>로 전달해도 된다.")
+    private Position pos;
+
+    @Schema(description = "<p>가한 데미지 (for hero)" +
+            "<p>해당하지 않는 경우(boss인 경우) <code>null</code>로 전달해도 된다.",
+            example = "5")
+    private Integer damageDealt;
+
+    @Schema(description = "<p>모션 (for hero)" +
+            "<p>해당하지 않는 경우(boss인 경우) <code>null</code>로 전달해도 된다.",
+            example = "3")
+    private Integer motion;
+
+    // For boss
+    @Schema(description = "<p>사용한 스킬 (for boss)." +
+            "<p>해당하지 않는 경우(hero인 경우) <code>null</code>로 전달해도 된다.",
+            example = "")
+    private Integer skillUsed;
+}

--- a/src/main/java/ajou/mse/dimensionguard/dto/in_game/response/InGameResponse.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/in_game/response/InGameResponse.java
@@ -1,0 +1,30 @@
+package ajou.mse.dimensionguard.dto.in_game.response;
+
+import ajou.mse.dimensionguard.dto.player.PlayerDto;
+import ajou.mse.dimensionguard.dto.player.response.PlayerResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class InGameResponse {
+
+    @Schema(description = "보스가 사용한 스킬", example = "10")
+    private Integer skillUsed;
+
+    @Schema(description = "게임에 참여중인 플레이어들의 정보")
+    private List<PlayerResponse> players;
+
+    public static InGameResponse of(Integer skillUsed, List<PlayerDto> players) {
+        return new InGameResponse(
+                skillUsed,
+                players.stream()
+                        .map(PlayerResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/dto/player/response/PlayerResponse.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/player/response/PlayerResponse.java
@@ -4,7 +4,6 @@ import ajou.mse.dimensionguard.domain.player.Position;
 import ajou.mse.dimensionguard.dto.member.response.MemberResponse;
 import ajou.mse.dimensionguard.dto.player.PlayerDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -16,7 +15,7 @@ public class PlayerResponse {
     private Integer id;
 
     @Schema(description = "회원 정보")
-    private MemberResponse memberDto;
+    private MemberResponse member;
 
     @Schema(description = "참여중인 게임 룸의 PK", example = "2")
     private Integer roomId;

--- a/src/main/java/ajou/mse/dimensionguard/dto/redis/InGameRequestStatus.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/redis/InGameRequestStatus.java
@@ -1,0 +1,34 @@
+package ajou.mse.dimensionguard.dto.redis;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import static ajou.mse.dimensionguard.constant.ConstantUtil.IN_GAME_REQUEST_STATUS_TIMEOUT;
+
+@Getter
+@RedisHash(value = "requestStatus", timeToLive = IN_GAME_REQUEST_STATUS_TIMEOUT)
+public class InGameRequestStatus {
+
+    @Id
+    private Integer roomId;
+
+    @Setter(AccessLevel.PRIVATE)
+    private Integer count;
+
+    public InGameRequestStatus(Integer roomId) {
+        this.roomId = roomId;
+        this.count = 0;
+    }
+
+    public void increaseRequestCount() {
+        int nextCount = this.getCount() + 1;
+        this.setCount(nextCount);
+    }
+
+    public void initRequestCount() {
+        this.setCount(0);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/dto/redis/SkillInfo.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/redis/SkillInfo.java
@@ -1,0 +1,38 @@
+package ajou.mse.dimensionguard.dto.redis;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.time.LocalDateTime;
+
+import static ajou.mse.dimensionguard.constant.ConstantUtil.SKILL_INFO_TIMEOUT;
+
+@Getter
+@RedisHash(value = "skill", timeToLive = SKILL_INFO_TIMEOUT)
+public class SkillInfo {
+
+    @Id
+    private Integer roomId;
+
+    private Integer skillId;
+
+    @Setter(AccessLevel.PRIVATE)
+    private Integer deliveredCount;
+
+    private LocalDateTime createdAt;
+
+    public SkillInfo(Integer roomId, Integer skillId) {
+        this.roomId = roomId;
+        this.skillId = skillId;
+        this.deliveredCount = 0;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void increaseDeliveredCount() {
+        int nextDeliveredCount = this.getDeliveredCount() + 1;
+        this.setDeliveredCount(nextDeliveredCount);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/exception/ExceptionType.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/ExceptionType.java
@@ -12,10 +12,7 @@ import ajou.mse.dimensionguard.exception.member.MemberIdNotFoundException;
 import ajou.mse.dimensionguard.exception.member.MemberNameDuplicateException;
 import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberAndRoomException;
 import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberIdException;
-import ajou.mse.dimensionguard.exception.room.AlreadyParticipatingException;
-import ajou.mse.dimensionguard.exception.room.EveryoneNotReadyException;
-import ajou.mse.dimensionguard.exception.room.GameStartException;
-import ajou.mse.dimensionguard.exception.room.RoomIdNotFoundException;
+import ajou.mse.dimensionguard.exception.room.*;
 import ajou.mse.dimensionguard.log.LogUtils;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -109,10 +106,11 @@ public enum ExceptionType {
     /**
      * 게임 룸({@link Room}) 관련 예외
      */
-    ROOM_ID_NOT_FOUND(2500, "게임 방을 찾을 수 없습니다. 해산되거나 게임이 시작된 방일 수 있습니다.", RoomIdNotFoundException.class),
+    ROOM_ID_NOT_FOUND(2500, "게임 방을 찾을 수 없습니다. 방이 해산됐거나 게임이 종료되었을 수 있습니다.", RoomIdNotFoundException.class),
     GAME_START(2501, "알 수 없는 이유로 게임을 시작할 수 없습니다.", GameStartException.class),
     EVERYONE_NOT_READY(2502, "참가자들의 준비를 기다렸으나, 참가자 전원의 준비가 되지 않았습니다.", EveryoneNotReadyException.class),
     ALREADY_PARTICIPATING(2503, "이미 다른 방에 참여중입니다. 참여중인 방에서 나간 후 다시 시도해주세요.", AlreadyParticipatingException.class),
+    ROOM_NOT_FOUND_BY_MEMBER_ID(2504, "게임 방을 찾을 수 없습니다. 방이 해산됐거나 게임이 종료되었을 수 있습니다.", RoomNotFoundByMemberIdException.class),
 
     /**
      * 플레이어({@link Player}) 관련 예외

--- a/src/main/java/ajou/mse/dimensionguard/exception/room/RoomNotFoundByMemberIdException.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/room/RoomNotFoundByMemberIdException.java
@@ -1,0 +1,9 @@
+package ajou.mse.dimensionguard.exception.room;
+
+import ajou.mse.dimensionguard.exception.common.NotFoundException;
+
+public class RoomNotFoundByMemberIdException extends NotFoundException {
+    public RoomNotFoundByMemberIdException(Integer memberId) {
+        super("memberId=" + memberId);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/log/aop/Pointcuts.java
+++ b/src/main/java/ajou/mse/dimensionguard/log/aop/Pointcuts.java
@@ -10,6 +10,7 @@ public class Pointcuts {
     @Pointcut("execution(* ajou.mse.dimensionguard.service..*(..))")
     public void servicePoint(){}
 
-    @Pointcut("execution(* ajou.mse.dimensionguard.repository..*(..))")
+    @Pointcut("execution(* ajou.mse.dimensionguard.repository..*(..)) && " +
+            "!execution(* org.springframework.data.repository.CrudRepository.*(..))")
     public void repositoryPoint(){}
 }

--- a/src/main/java/ajou/mse/dimensionguard/repository/redis/InGameRequestStatusRepository.java
+++ b/src/main/java/ajou/mse/dimensionguard/repository/redis/InGameRequestStatusRepository.java
@@ -1,0 +1,7 @@
+package ajou.mse.dimensionguard.repository.redis;
+
+import ajou.mse.dimensionguard.dto.redis.InGameRequestStatus;
+import org.springframework.data.repository.CrudRepository;
+
+public interface InGameRequestStatusRepository extends CrudRepository<InGameRequestStatus, Integer> {
+}

--- a/src/main/java/ajou/mse/dimensionguard/repository/redis/SkillInfoRepository.java
+++ b/src/main/java/ajou/mse/dimensionguard/repository/redis/SkillInfoRepository.java
@@ -1,0 +1,7 @@
+package ajou.mse.dimensionguard.repository.redis;
+
+import ajou.mse.dimensionguard.dto.redis.SkillInfo;
+import org.springframework.data.repository.CrudRepository;
+
+public interface SkillInfoRepository extends CrudRepository<SkillInfo, Integer> {
+}

--- a/src/main/java/ajou/mse/dimensionguard/repository/room/RoomRepository.java
+++ b/src/main/java/ajou/mse/dimensionguard/repository/room/RoomRepository.java
@@ -1,4 +1,4 @@
-package ajou.mse.dimensionguard.repository;
+package ajou.mse.dimensionguard.repository.room;
 
 import ajou.mse.dimensionguard.constant.room.RoomStatus;
 import ajou.mse.dimensionguard.domain.Room;
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface RoomRepository extends JpaRepository<Room, Integer> {
+public interface RoomRepository extends
+        JpaRepository<Room, Integer>,
+        RoomRepositoryQCustom {
 
     List<Room> findAllByStatus(RoomStatus status);
 }

--- a/src/main/java/ajou/mse/dimensionguard/repository/room/RoomRepositoryQCustom.java
+++ b/src/main/java/ajou/mse/dimensionguard/repository/room/RoomRepositoryQCustom.java
@@ -1,0 +1,16 @@
+package ajou.mse.dimensionguard.repository.room;
+
+import ajou.mse.dimensionguard.domain.Room;
+
+import java.util.Optional;
+
+public interface RoomRepositoryQCustom {
+
+    /**
+     * memberId에 해당하는 회원이 참여중인 room을 조회한다.
+     *
+     * @param memberId PK of member
+     * @return 조회된 room
+     */
+    Optional<Room> findByMemberId(Integer memberId);
+}

--- a/src/main/java/ajou/mse/dimensionguard/repository/room/RoomRepositoryQCustomImpl.java
+++ b/src/main/java/ajou/mse/dimensionguard/repository/room/RoomRepositoryQCustomImpl.java
@@ -1,0 +1,27 @@
+package ajou.mse.dimensionguard.repository.room;
+
+import ajou.mse.dimensionguard.domain.Room;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static ajou.mse.dimensionguard.domain.QRoom.room;
+import static ajou.mse.dimensionguard.domain.player.QPlayer.player;
+
+@RequiredArgsConstructor
+public class RoomRepositoryQCustomImpl implements RoomRepositoryQCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Room> findByMemberId(Integer memberId) {
+        return Optional.ofNullable(
+                queryFactory.select(room)
+                        .from(player)
+                        .join(player.room, room)
+                        .where(player.member.id.eq(memberId))
+                        .fetchOne()
+        );
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/service/BossSkillService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/BossSkillService.java
@@ -1,0 +1,50 @@
+package ajou.mse.dimensionguard.service;
+
+import ajou.mse.dimensionguard.dto.redis.SkillInfo;
+import ajou.mse.dimensionguard.repository.redis.SkillInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class BossSkillService {
+
+    private final SkillInfoRepository skillInfoRepository;
+
+    @Transactional
+    public void addSkill(Integer roomId, Integer skillId) {
+        SkillInfo skillInfo = new SkillInfo(roomId, skillId);
+        skillInfoRepository.save(skillInfo);
+    }
+
+    @Transactional
+    public Integer getSkillUsed(Integer roomId, Integer numOfPlayers) {
+        Optional<SkillInfo> optionalSkillInfo = skillInfoRepository.findById(roomId);
+
+        if (optionalSkillInfo.isEmpty()) {
+            System.out.println(11111);
+            return null;
+        }
+
+        System.out.println(22222);
+        SkillInfo skillInfo = optionalSkillInfo.get();
+        skillInfo.increaseDeliveredCount();
+        skillInfoRepository.save(skillInfo);
+
+        SkillInfo updatedSkillInfo = skillInfoRepository.findById(roomId).orElseThrow();
+        if (updatedSkillInfo.getDeliveredCount().equals(numOfPlayers)) {
+            skillInfoRepository.deleteById(roomId);
+        }
+
+        return skillInfo.getSkillId();
+    }
+
+    @Transactional
+    public void clear() {
+        skillInfoRepository.deleteAll();
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/service/GameSyncService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/GameSyncService.java
@@ -2,10 +2,10 @@ package ajou.mse.dimensionguard.service;
 
 import ajou.mse.dimensionguard.domain.Room;
 import ajou.mse.dimensionguard.domain.player.Player;
+import ajou.mse.dimensionguard.dto.redis.InGameRequestStatus;
 import ajou.mse.dimensionguard.exception.room.EveryoneNotReadyException;
 import ajou.mse.dimensionguard.exception.room.GameStartException;
-import ajou.mse.dimensionguard.service.PlayerService;
-import ajou.mse.dimensionguard.service.RoomService;
+import ajou.mse.dimensionguard.repository.redis.InGameRequestStatusRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
@@ -14,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import java.util.List;
 
+import static ajou.mse.dimensionguard.constant.ConstantUtil.*;
+
 @RequiredArgsConstructor
 @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
 @Service
@@ -21,7 +23,24 @@ public class GameSyncService {
 
     private final RoomService roomService;
     private final PlayerService playerService;
+    private final InGameRequestStatusRepository inGameRequestStatusRepository;
     private final EntityManager entityManager;
+
+    @Transactional
+    public void increaseRequestCount(Integer roomId) {
+        InGameRequestStatus inGameRequestStatus = findInGameReqStatus(roomId);
+        inGameRequestStatus.increaseRequestCount();
+        inGameRequestStatusRepository.save(inGameRequestStatus);
+    }
+
+    @Transactional
+    public void initRequestCount(Integer roomId) {
+        InGameRequestStatus inGameRequestStatus = findInGameReqStatus(roomId);
+        if (inGameRequestStatus.getCount() != 0) {
+            inGameRequestStatus.initRequestCount();
+            inGameRequestStatusRepository.save(inGameRequestStatus);
+        }
+    }
 
     public void waitUntilEveryoneIsReady(Integer roomId) {
         Room room = roomService.findEntityById(roomId);
@@ -29,19 +48,42 @@ public class GameSyncService {
         int count = 0;
         try {
             while (!checkEveryoneIsReady(room)) {
-                if (++count > 30) {
+                if (++count > WAITING_COUNT_FOR_READY) {
                     throw new EveryoneNotReadyException();
                 }
-                Thread.sleep(500);
+                Thread.sleep(SLEEP_MILLIS_FOR_READY);
             }
         } catch (InterruptedException ex) {
             throw new GameStartException(ex);
         }
     }
 
+    public void waitUntilEveryoneRequest(Integer roomId) {
+        Room room = roomService.findEntityById(roomId);
+        int numOfPlayers = room.getPlayers().size();
+
+        int threadLoopCount = 0;
+        try {
+            while (!isEveryoneRequest(roomId, numOfPlayers)) {
+                if (++threadLoopCount > WAITING_COUNT_FOR_REQUEST) return;
+                Thread.sleep(SLEEP_MILLIS_FOR_REQUEST);
+            }
+        } catch (InterruptedException ignored) {
+        }
+    }
+
+    private InGameRequestStatus findInGameReqStatus(Integer roomId) {
+        return inGameRequestStatusRepository.findById(roomId)
+                .orElseGet(() -> inGameRequestStatusRepository.save(new InGameRequestStatus(roomId)));
+    }
+
     private boolean checkEveryoneIsReady(Room room) {
         entityManager.clear();
         List<Player> players = playerService.findAllEntityByRoom(room);
         return players.stream().allMatch(Player::getIsReady);
+    }
+
+    private boolean isEveryoneRequest(Integer roomId, Integer numOfPlayers) {
+        return this.findInGameReqStatus(roomId).getCount().equals(numOfPlayers);
     }
 }

--- a/src/main/java/ajou/mse/dimensionguard/service/InGameService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/InGameService.java
@@ -1,0 +1,58 @@
+package ajou.mse.dimensionguard.service;
+
+import ajou.mse.dimensionguard.domain.Room;
+import ajou.mse.dimensionguard.domain.player.Boss;
+import ajou.mse.dimensionguard.domain.player.Hero;
+import ajou.mse.dimensionguard.dto.in_game.request.PlayerInGameRequest;
+import ajou.mse.dimensionguard.dto.in_game.response.InGameResponse;
+import ajou.mse.dimensionguard.dto.room.RoomDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class InGameService {
+
+    private final PlayerService playerService;
+    private final RoomService roomService;
+    private final BossSkillService bossSkillService;
+
+    @Transactional
+    public void updateInGameData(Integer loginMemberId, PlayerInGameRequest request) {
+        if (request.getIsBoss()) {
+            bossSkillService.clear();
+            Room room = roomService.findEntityByMemberId(loginMemberId);
+            bossSkillService.addSkill(room.getId(), request.getSkillUsed());
+        } else {
+            Hero hero = (Hero) playerService.findEntityByMemberId(loginMemberId);
+            hero.update(
+                    request.getHp(),
+                    request.getEnergy(),
+                    request.getPos(),
+                    request.getDamageDealt(),
+                    request.getMotion()
+            );
+
+            Room room = hero.getRoom();
+
+            Optional<Boss> optionalBoss = room.getPlayers().stream()
+                    .filter(player -> player instanceof Boss)
+                    .findFirst()
+                    .map(Boss.class::cast);
+            optionalBoss.ifPresent(boss -> boss.decreaseHp(request.getDamageDealt()));
+        }
+    }
+
+    public InGameResponse getInGameData(Integer roomId) {
+        RoomDto roomDto = roomService.findDtoById(roomId);
+
+        int numOfPlayers = roomDto.getPlayerDtos().size();
+        Integer skillUsed = bossSkillService.getSkillUsed(roomId, numOfPlayers);
+
+        return InGameResponse.of(skillUsed, roomDto.getPlayerDtos());
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/service/PlayerService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/PlayerService.java
@@ -5,7 +5,7 @@ import ajou.mse.dimensionguard.domain.player.Player;
 import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberAndRoomException;
 import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberIdException;
 import ajou.mse.dimensionguard.repository.PlayerRepository;
-import ajou.mse.dimensionguard.repository.RoomRepository;
+import ajou.mse.dimensionguard.repository.room.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
@@ -10,7 +10,8 @@ import ajou.mse.dimensionguard.dto.room.RoomDto;
 import ajou.mse.dimensionguard.dto.room.response.CheckGameStartResponse;
 import ajou.mse.dimensionguard.exception.room.AlreadyParticipatingException;
 import ajou.mse.dimensionguard.exception.room.RoomIdNotFoundException;
-import ajou.mse.dimensionguard.repository.RoomRepository;
+import ajou.mse.dimensionguard.exception.room.RoomNotFoundByMemberIdException;
+import ajou.mse.dimensionguard.repository.room.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,7 +58,12 @@ public class RoomService {
                 .orElseThrow(() -> new RoomIdNotFoundException(roomId));
     }
 
-    private RoomDto findDtoById(Integer roomId) {
+    public Room findEntityByMemberId(Integer memberId) {
+        return roomRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new RoomNotFoundByMemberIdException(memberId));
+    }
+
+    public RoomDto findDtoById(Integer roomId) {
         return RoomDto.from(findEntityById(roomId));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,9 @@ logging:
       springframework.jdbc: debug
 
 spring:
+  redis:
+    host: localhost
+    port: 6379
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## 🔥 Related Issue
- Close #27

## 🏃‍ Task
- In-game 정보 갱신 API를 구현한다. 이 API는 다음의 기능들을 포함해야 한다.
  - Hero
    - 현재 내 상태 및 보스 체력 update
  - Boss
    - 현재 내 상태 update
    - Skill queue 구현 및 모든 유저에게 전달

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
