### PR TITLE
게임 룸 생성 시 `Player`의 일부 not null 값에 null이 들어가 에러가 발생하는 버그 수정

### DIFF
--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Boss.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Boss.java
@@ -6,7 +6,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import java.time.LocalDateTime;
@@ -20,10 +19,8 @@ import static ajou.mse.dimensionguard.constant.ConstantUtil.BOSS_MAX_HP;
 @Entity
 public class Boss extends Player {
 
-    @Column(nullable = false)
     private Integer numOfSkillUsed;
 
-    @Column(nullable = false)
     private Integer numOfSkillHit;
 
     public static Boss of(Member member, Room room) {

--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Hero.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Hero.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -32,10 +31,8 @@ public class Hero extends Player {
     @Setter(AccessLevel.PRIVATE)
     private Integer motion;
 
-    @Column(nullable = false)
     private Integer totalDamageDealt;
 
-    @Column(nullable = false)
     private Integer totalDamageTaken;
 
     public static Hero of(Member member, Room room) {


### PR DESCRIPTION
## 🔥 Related Issue
- Close #42

## 🏃‍ Task
- `Hero`의 not null 값이었던 `totalDamageDealt`와 `totalDamageTaken`의 제약조건 해제
- `Boss`의 not null 값이었던 `numOfSkillUsed`와 `numOfSkillHit`의 제약조건 해제

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
