### PR TITLE
게임 종료 및 게임 기록 저장/조회 기능 구현

### DIFF
--- a/src/main/java/ajou/mse/dimensionguard/constant/GameResult.java
+++ b/src/main/java/ajou/mse/dimensionguard/constant/GameResult.java
@@ -1,0 +1,5 @@
+package ajou.mse.dimensionguard.constant;
+
+public enum GameResult {
+    NOT_END, HERO_WIN, BOSS_WIN
+}

--- a/src/main/java/ajou/mse/dimensionguard/controller/RecordController.java
+++ b/src/main/java/ajou/mse/dimensionguard/controller/RecordController.java
@@ -1,0 +1,33 @@
+package ajou.mse.dimensionguard.controller;
+
+import ajou.mse.dimensionguard.dto.record.RecordDto;
+import ajou.mse.dimensionguard.dto.record.response.RecordResponse;
+import ajou.mse.dimensionguard.service.RecordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Record & Statistics")
+@RequiredArgsConstructor
+@RequestMapping("/api/record")
+@RestController
+public class RecordController {
+
+    private final RecordService recordService;
+
+    @Operation(
+            summary = "Find game record by game room ID.",
+            description = "<p>Get a record of games that have ended by game room ID(<code>roomId</code>).",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @GetMapping
+    public RecordResponse findByRoomId(@RequestParam Long roomId) {
+        RecordDto recordDto = recordService.findDtoByRoomId(roomId);
+        return RecordResponse.from(recordDto);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/domain/record/PlayerRecord.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/record/PlayerRecord.java
@@ -1,0 +1,59 @@
+package ajou.mse.dimensionguard.domain.record;
+
+import ajou.mse.dimensionguard.domain.BaseTimeEntity;
+import ajou.mse.dimensionguard.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class PlayerRecord extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "player_record_id")
+    private Long id;
+
+    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "record_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Record record;
+
+    private Boolean isBoss;
+
+    private Integer totalDamageDealt;
+
+    private Integer totalDamageTaken;
+
+    private Integer numOfSkillUsed;
+
+    private Integer numOfSkillHit;
+
+    public static PlayerRecord of(Member member, Record record, Boolean isBoss, Integer totalDamageDealt, Integer totalDamageTaken, Integer numOfSkillUsed, Integer numOfSkillHit) {
+        return of(null, member, record, isBoss, totalDamageDealt, totalDamageTaken, numOfSkillUsed, numOfSkillHit, null, null);
+    }
+
+    public static PlayerRecord of(Long id, Member member, Record record, Boolean isBoss, Integer totalDamageDealt, Integer totalDamageTaken, Integer numOfSkillUsed, Integer numOfSkillHit, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new PlayerRecord(id, member, record, isBoss, totalDamageDealt, totalDamageTaken, numOfSkillUsed, numOfSkillHit, createdAt, updatedAt);
+    }
+
+    public PlayerRecord(Long id, Member member, Record record, Boolean isBoss, Integer totalDamageDealt, Integer totalDamageTaken, Integer numOfSkillUsed, Integer numOfSkillHit, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        super(createdAt, updatedAt);
+        this.id = id;
+        this.member = member;
+        this.record = record;
+        this.isBoss = isBoss;
+        this.totalDamageDealt = totalDamageDealt;
+        this.totalDamageTaken = totalDamageTaken;
+        this.numOfSkillUsed = numOfSkillUsed;
+        this.numOfSkillHit = numOfSkillHit;
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/domain/record/Record.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/record/Record.java
@@ -1,0 +1,52 @@
+package ajou.mse.dimensionguard.domain.record;
+
+import ajou.mse.dimensionguard.constant.GameResult;
+import ajou.mse.dimensionguard.domain.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.LinkedList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Record extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "record_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Long roomId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private GameResult result;
+
+    @Column(nullable = false)
+    private Long playTimeSec;
+
+    @OneToMany(mappedBy = "record")
+    private List<PlayerRecord> playerRecords = new LinkedList<>();
+
+    public static Record of(Long roomId, GameResult result, Long playTimeSec) {
+        return of(null, roomId, result, playTimeSec, null, null);
+    }
+
+    public static Record of(Long id, Long roomId, GameResult result, Long playTimeSec, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new Record(id, roomId, result, playTimeSec, createdAt, updatedAt);
+    }
+
+    private Record(Long id, Long roomId, GameResult result, Long playTimeSec, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        super(createdAt, updatedAt);
+        this.id = id;
+        this.roomId = roomId;
+        this.result = result;
+        this.playTimeSec = playTimeSec;
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/dto/player/PlayerDto.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/player/PlayerDto.java
@@ -1,10 +1,10 @@
 package ajou.mse.dimensionguard.dto.player;
 
+import ajou.mse.dimensionguard.domain.player.Boss;
 import ajou.mse.dimensionguard.domain.player.Hero;
 import ajou.mse.dimensionguard.domain.player.Player;
 import ajou.mse.dimensionguard.domain.player.Position;
 import ajou.mse.dimensionguard.dto.member.MemberDto;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -22,13 +22,21 @@ public class PlayerDto {
     private Position position;
     private Integer damageDealt;
     private Integer motion;
+    private Integer totalDamageDealt;
+    private Integer totalDamageTaken;
+    private Integer numOfSkillUsed;
+    private Integer numOfSkillHit;
 
     public static PlayerDto from(Player entity) {
-        boolean isBoss = true;
+        boolean isBoss;
         Hero hero = null;
+        Boss boss = null;
         if (entity instanceof Hero) {
             isBoss = false;
             hero = (Hero) entity;
+        } else {
+            isBoss = true;
+            boss = (Boss) entity;
         }
 
         return new PlayerDto(
@@ -41,7 +49,11 @@ public class PlayerDto {
                 entity.getEnergy(),
                 hero == null ? null : hero.getPos(),
                 hero == null ? null : hero.getDamageDealt(),
-                hero == null ? null : hero.getMotion()
+                hero == null ? null : hero.getMotion(),
+                hero == null ? null : hero.getTotalDamageDealt(),
+                hero == null ? null : hero.getTotalDamageTaken(),
+                boss == null ? null : boss.getNumOfSkillUsed(),
+                boss == null ? null : boss.getNumOfSkillHit()
         );
     }
 }

--- a/src/main/java/ajou/mse/dimensionguard/dto/record/PlayerRecordDto.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/record/PlayerRecordDto.java
@@ -12,6 +12,7 @@ public class PlayerRecordDto {
     private Long id;
     private MemberDto memberDto;
     private Long recordId;
+    private Boolean isBoss;
     private Integer totalDamageDealt;
     private Integer totalDamageTaken;
     private Integer numOfSkillUsed;
@@ -22,6 +23,7 @@ public class PlayerRecordDto {
                 entity.getId(),
                 MemberDto.from(entity.getMember()),
                 entity.getRecord().getId(),
+                entity.getIsBoss(),
                 entity.getTotalDamageDealt(),
                 entity.getTotalDamageTaken(),
                 entity.getNumOfSkillUsed(),

--- a/src/main/java/ajou/mse/dimensionguard/dto/record/PlayerRecordDto.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/record/PlayerRecordDto.java
@@ -1,0 +1,31 @@
+package ajou.mse.dimensionguard.dto.record;
+
+import ajou.mse.dimensionguard.domain.record.PlayerRecord;
+import ajou.mse.dimensionguard.dto.member.MemberDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PlayerRecordDto {
+
+    private Long id;
+    private MemberDto memberDto;
+    private Long recordId;
+    private Integer totalDamageDealt;
+    private Integer totalDamageTaken;
+    private Integer numOfSkillUsed;
+    private Integer numOfSkillHit;
+
+    public static PlayerRecordDto from(PlayerRecord entity) {
+        return new PlayerRecordDto(
+                entity.getId(),
+                MemberDto.from(entity.getMember()),
+                entity.getRecord().getId(),
+                entity.getTotalDamageDealt(),
+                entity.getTotalDamageTaken(),
+                entity.getNumOfSkillUsed(),
+                entity.getNumOfSkillHit()
+        );
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/dto/record/RecordDto.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/record/RecordDto.java
@@ -1,0 +1,28 @@
+package ajou.mse.dimensionguard.dto.record;
+
+import ajou.mse.dimensionguard.domain.record.Record;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class RecordDto {
+
+    private Long id;
+    private Long roomId;
+    private Long playTimeSec;
+    private List<PlayerRecordDto> playerRecordDtos;
+
+    public static RecordDto from(Record entity) {
+        return new RecordDto(
+                entity.getId(),
+                entity.getRoomId(),
+                entity.getPlayTimeSec(),
+                entity.getPlayerRecords().stream()
+                        .map(PlayerRecordDto::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/dto/record/response/PlayerRecordResponse.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/record/response/PlayerRecordResponse.java
@@ -1,0 +1,45 @@
+package ajou.mse.dimensionguard.dto.record.response;
+
+import ajou.mse.dimensionguard.dto.member.response.MemberResponse;
+import ajou.mse.dimensionguard.dto.record.PlayerRecordDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PlayerRecordResponse {
+
+    @Schema(description = "PK of player record", example = "7")
+    private Long id;
+
+    @Schema(description = "Member information that was played")
+    private MemberResponse memberDto;
+
+    @Schema(description = "Weather or not the player is boss", example = "false")
+    private Boolean isBoss;
+
+    @Schema(description = "Total damage dealt to the boss (Hero only)", example = "50")
+    private Integer totalDamageDealt;
+
+    @Schema(description = "The total amount of damage taken (Hero only)", example = "20")
+    private Integer totalDamageTaken;
+
+    @Schema(description = "Total number of times the skill was used (Boss only)", example = "5")
+    private Integer numOfSkillUsed;
+
+    @Schema(description = "The total number of times the skill has been hit (Boss only)", example = "3")
+    private Integer numOfSkillHit;
+
+    public static PlayerRecordResponse from(PlayerRecordDto dto) {
+        return new PlayerRecordResponse(
+                dto.getId(),
+                MemberResponse.from(dto.getMemberDto()),
+                dto.getIsBoss(),
+                dto.getTotalDamageDealt(),
+                dto.getTotalDamageTaken(),
+                dto.getNumOfSkillUsed(),
+                dto.getNumOfSkillHit()
+        );
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/dto/record/response/RecordResponse.java
+++ b/src/main/java/ajou/mse/dimensionguard/dto/record/response/RecordResponse.java
@@ -1,0 +1,36 @@
+package ajou.mse.dimensionguard.dto.record.response;
+
+import ajou.mse.dimensionguard.dto.record.RecordDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class RecordResponse {
+
+    @Schema(description = "PK of record", example = "6")
+    private Long id;
+
+    @Schema(description = "PK of room", example = "3")
+    private Long roomId;
+
+    @Schema(description = "Play time(sec)", example = "162")
+    private Long playTimeSec;
+
+    @Schema(description = "A record list of players who participated in the game.")
+    private List<PlayerRecordResponse> playerRecords;
+
+    public static RecordResponse from(RecordDto dto) {
+        return new RecordResponse(
+                dto.getId(),
+                dto.getRoomId(),
+                dto.getPlayTimeSec(),
+                dto.getPlayerRecordDtos().stream()
+                        .map(PlayerRecordResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/exception/ExceptionType.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/ExceptionType.java
@@ -12,6 +12,7 @@ import ajou.mse.dimensionguard.exception.member.MemberIdNotFoundException;
 import ajou.mse.dimensionguard.exception.member.MemberNameDuplicateException;
 import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberAndRoomException;
 import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberIdException;
+import ajou.mse.dimensionguard.exception.record.RecordNotFoundByRoomIdException;
 import ajou.mse.dimensionguard.exception.room.*;
 import ajou.mse.dimensionguard.log.LogUtils;
 import lombok.AccessLevel;
@@ -48,6 +49,7 @@ import java.util.Optional;
  *     <li>2000 ~ 2499: 회원({@link Member}) 관련 예외</li>
  *     <li>2500 ~ 2999: 게임 룸({@link Room}) 관련 예외</li>
  *     <li>3000 ~ 3399: 플레이어({@link Player}) 관련 예외</li>
+ *     <li>3400 ~ 3699: 기록({@link Record}) 관련 예외</li>
  * </ul>
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -118,6 +120,11 @@ public enum ExceptionType {
      */
     PLAYER_NOT_FOUND_BY_MEMBER_AND_ROOM(3000, "플레이어를 찾을 수 없습니다.", PlayerNotFoundByMemberAndRoomException.class),
     PLAYER_NOT_FOUND_BY_MEMBER(3001, "플레이어를 찾을 수 없습니다.", PlayerNotFoundByMemberIdException.class),
+
+    /**
+     * 기록({@link Record}) 관련 예외
+     */
+    RECORD_NOT_FOUND_BY_ROOM_ID(3400, "게임 기록을 찾을 수 없습니다.", RecordNotFoundByRoomIdException.class),
     ;
 
     private final Integer code;

--- a/src/main/java/ajou/mse/dimensionguard/exception/record/RecordNotFoundByRoomIdException.java
+++ b/src/main/java/ajou/mse/dimensionguard/exception/record/RecordNotFoundByRoomIdException.java
@@ -1,0 +1,9 @@
+package ajou.mse.dimensionguard.exception.record;
+
+import ajou.mse.dimensionguard.exception.common.NotFoundException;
+
+public class RecordNotFoundByRoomIdException extends NotFoundException {
+    public RecordNotFoundByRoomIdException(Long roomId) {
+        super("roomId=" + roomId);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/repository/record/PlayerRecordRepository.java
+++ b/src/main/java/ajou/mse/dimensionguard/repository/record/PlayerRecordRepository.java
@@ -1,0 +1,7 @@
+package ajou.mse.dimensionguard.repository.record;
+
+import ajou.mse.dimensionguard.domain.record.PlayerRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlayerRecordRepository extends JpaRepository<PlayerRecord, Long> {
+}

--- a/src/main/java/ajou/mse/dimensionguard/repository/record/RecordRepository.java
+++ b/src/main/java/ajou/mse/dimensionguard/repository/record/RecordRepository.java
@@ -1,0 +1,11 @@
+package ajou.mse.dimensionguard.repository.record;
+
+import ajou.mse.dimensionguard.domain.record.Record;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RecordRepository extends JpaRepository<Record, Long> {
+
+    Optional<Record> findByRoomId(Long roomId);
+}

--- a/src/main/java/ajou/mse/dimensionguard/service/InGameService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/InGameService.java
@@ -1,5 +1,6 @@
 package ajou.mse.dimensionguard.service;
 
+import ajou.mse.dimensionguard.constant.GameResult;
 import ajou.mse.dimensionguard.domain.Room;
 import ajou.mse.dimensionguard.domain.player.Boss;
 import ajou.mse.dimensionguard.domain.player.Hero;
@@ -43,6 +44,27 @@ public class InGameService {
                         .map(PlayerResponse::from)
                         .toList()
         );
+    }
+
+    public GameResult isGameEnded(Long roomId) {
+        Room room = roomService.findById(roomId);
+
+        // 모든 hero들의 hp가 0이거나
+        long count = room.getPlayers().stream()
+                .filter(player -> player instanceof Hero)
+                .filter(player -> player.getHp() != 0)
+                .count();
+        if (count <= 0) {
+            return GameResult.BOSS_WIN;
+        }
+
+        // boss의 hp가 0이하라면 return true
+        Boss boss = getBossFromRoom(room);
+        if (boss.getHp() <= 0) {
+            return GameResult.HERO_WIN;
+        }
+
+        return GameResult.NOT_END;
     }
 
     private void updateInGameDataForBoss(Long loginMemberId, PlayerInGameRequest request) {

--- a/src/main/java/ajou/mse/dimensionguard/service/RecordService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/RecordService.java
@@ -51,4 +51,12 @@ public class RecordService {
 
         return RecordDto.from(record);
     }
+
+    public RecordDto findDtoByRoomId(Long roomId) {
+        return RecordDto.from(findByRoomId(roomId));
+    }
+
+    private Record findByRoomId(Long roomId) {
+        return recordRepository.findByRoomId(roomId).orElseThrow(() -> new RecordNotFoundByRoomIdException(roomId));
+    }
 }

--- a/src/main/java/ajou/mse/dimensionguard/service/RecordService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/RecordService.java
@@ -1,0 +1,54 @@
+package ajou.mse.dimensionguard.service;
+
+import ajou.mse.dimensionguard.constant.GameResult;
+import ajou.mse.dimensionguard.domain.Member;
+import ajou.mse.dimensionguard.domain.record.PlayerRecord;
+import ajou.mse.dimensionguard.domain.record.Record;
+import ajou.mse.dimensionguard.dto.record.RecordDto;
+import ajou.mse.dimensionguard.dto.room.RoomDto;
+import ajou.mse.dimensionguard.exception.record.RecordNotFoundByRoomIdException;
+import ajou.mse.dimensionguard.repository.record.PlayerRecordRepository;
+import ajou.mse.dimensionguard.repository.record.RecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class RecordService {
+
+    private final MemberService memberService;
+    private final RecordRepository recordRepository;
+    private final PlayerRecordRepository playerRecordRepository;
+
+    @Transactional
+    public RecordDto record(RoomDto roomDto, GameResult gameResult) {
+        Duration duration = Duration.between(roomDto.getGameStartedAt(), LocalDateTime.now());
+        Record record = Record.of(roomDto.getId(), gameResult, duration.toSeconds());
+        recordRepository.save(record);
+
+        List<PlayerRecord> playerRecords = roomDto.getPlayerDtos().stream()
+                .map(dto -> {
+                    Member member = memberService.findById(dto.getMemberDto().getId());
+                    return PlayerRecord.of(
+                            member,
+                            record,
+                            dto.getIsBoss(),
+                            dto.getTotalDamageDealt(),
+                            dto.getTotalDamageTaken(),
+                            dto.getNumOfSkillUsed(),
+                            dto.getNumOfSkillHit()
+                    );
+                })
+                .toList();
+        playerRecordRepository.saveAll(playerRecords);
+        record.getPlayerRecords().addAll(playerRecords);
+
+        return RecordDto.from(record);
+    }
+}

--- a/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
@@ -105,6 +105,13 @@ public class RoomService {
         }
     }
 
+    @Transactional
+    public void deleteWithPlayers(Long roomId) {
+        Room room = findById(roomId);
+        playerService.deleteAll(room.getPlayers());
+        roomRepository.delete(room);
+    }
+
     private void validateAlreadyParticipating(Long loginMemberId) {
         Optional<Player> optionalPlayer = playerService.findOptByMemberId(loginMemberId);
         if (optionalPlayer.isPresent()) {


### PR DESCRIPTION
## 🔥 Related Issue
- Close #44

## 🏃‍ Task
-  게임 종료 조건 확인 로직 추가
- 게임 종료 시 기록 저장을 위한 기능 구현
- 저장된 게임 기록을 조회할 수 있는 API 구현

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
