### PR TITLE
게임 시작 시 보스의 체력을 인원수 * 100으로 설정하도록 초기화 로직 추가

### DIFF
--- a/src/main/java/ajou/mse/dimensionguard/constant/ConstantUtil.java
+++ b/src/main/java/ajou/mse/dimensionguard/constant/ConstantUtil.java
@@ -12,10 +12,10 @@ public class ConstantUtil {
     /**
      * Player 관련
      */
-    public static final int BOSS_MAX_HP = 100;
-    public static final int BOSS_MAX_ENERGY = 100;
-    public static final int HERO_MAX_HP = 100;
-    public static final int HERO_MAX_ENERGY = 100;
+    public static final int BOSS_DEFAULT_HP = 100;
+    public static final int BOSS_DEFAULT_ENERGY = 100;
+    public static final int HERO_DEFAULT_HP = 100;
+    public static final int HERO_DEFAULT_ENERGY = 100;
 
     /**
      * 보스 스킬 특정 상태값

--- a/src/main/java/ajou/mse/dimensionguard/controller/RoomController.java
+++ b/src/main/java/ajou/mse/dimensionguard/controller/RoomController.java
@@ -143,7 +143,7 @@ public class RoomController {
 
         try {
             gameSyncService.waitUntilEveryoneIsReady(roomId);
-            roomService.setGameStartedAt(roomId, LocalDateTime.now());
+            roomService.gameStart(roomId);
         } catch (Exception ex) {
             roomService.init(roomId);
             throw ex;

--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Boss.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Boss.java
@@ -10,8 +10,8 @@ import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import java.time.LocalDateTime;
 
-import static ajou.mse.dimensionguard.constant.ConstantUtil.BOSS_MAX_ENERGY;
-import static ajou.mse.dimensionguard.constant.ConstantUtil.BOSS_MAX_HP;
+import static ajou.mse.dimensionguard.constant.ConstantUtil.BOSS_DEFAULT_ENERGY;
+import static ajou.mse.dimensionguard.constant.ConstantUtil.BOSS_DEFAULT_HP;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -24,7 +24,7 @@ public class Boss extends Player {
     private Integer numOfSkillHit;
 
     public static Boss of(Member member, Room room) {
-        return of(null, member, room, false, BOSS_MAX_HP, BOSS_MAX_ENERGY, 0, 0, null, null);
+        return of(null, member, room, false, BOSS_DEFAULT_HP, BOSS_DEFAULT_ENERGY, 0, 0, null, null);
     }
 
     public static Boss of(Long id, Member member, Room room, Boolean isReady, Integer hp, Integer energy, Integer numOfSkillUsed, Integer numOfSkillHit, LocalDateTime createdAt, LocalDateTime updatedAt) {

--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Boss.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Boss.java
@@ -37,6 +37,10 @@ public class Boss extends Player {
         this.numOfSkillHit = numOfSkillHit;
     }
 
+    public void initHp(int numOfPlayers) {
+        this.setHp(BOSS_DEFAULT_HP * numOfPlayers);
+    }
+
     public void decreaseHp(Integer damageDealt) {
         this.setHp(this.getHp() - damageDealt);
     }

--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Hero.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Hero.java
@@ -12,8 +12,8 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import java.time.LocalDateTime;
 
-import static ajou.mse.dimensionguard.constant.ConstantUtil.HERO_MAX_ENERGY;
-import static ajou.mse.dimensionguard.constant.ConstantUtil.HERO_MAX_HP;
+import static ajou.mse.dimensionguard.constant.ConstantUtil.HERO_DEFAULT_ENERGY;
+import static ajou.mse.dimensionguard.constant.ConstantUtil.HERO_DEFAULT_HP;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -36,7 +36,7 @@ public class Hero extends Player {
     private Integer totalDamageTaken;
 
     public static Hero of(Member member, Room room) {
-        return of(null, member, room, false, HERO_MAX_HP, HERO_MAX_ENERGY, null, 0, 0, 0, 0, null, null);
+        return of(null, member, room, false, HERO_DEFAULT_HP, HERO_DEFAULT_ENERGY, null, 0, 0, 0, 0, null, null);
     }
 
     public static Hero of(Long id, Member member, Room room, Boolean isReady, Integer hp, Integer energy, Position pos, Integer damageDealt, Integer motion, Integer totalDamageDealt, Integer totalDamageTaken, LocalDateTime createdAt, LocalDateTime updatedAt) {

--- a/src/main/java/ajou/mse/dimensionguard/repository/player/PlayerRepository.java
+++ b/src/main/java/ajou/mse/dimensionguard/repository/player/PlayerRepository.java
@@ -1,4 +1,4 @@
-package ajou.mse.dimensionguard.repository;
+package ajou.mse.dimensionguard.repository.player;
 
 import ajou.mse.dimensionguard.domain.Room;
 import ajou.mse.dimensionguard.domain.player.Player;

--- a/src/main/java/ajou/mse/dimensionguard/service/PlayerService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/PlayerService.java
@@ -4,7 +4,7 @@ import ajou.mse.dimensionguard.domain.Room;
 import ajou.mse.dimensionguard.domain.player.Player;
 import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberAndRoomException;
 import ajou.mse.dimensionguard.exception.player.PlayerNotFoundByMemberIdException;
-import ajou.mse.dimensionguard.repository.PlayerRepository;
+import ajou.mse.dimensionguard.repository.player.PlayerRepository;
 import ajou.mse.dimensionguard.repository.room.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
## 🔥 Related Issue
- Close #50

## 🏃‍ Task
- 게임 시작 시 보스의 체력을 인원수 * 100으로 설정하도록 초기화 로직 추가

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
