### PR TITLE
게임 종료 시 Record가 인원수만큼 중복 생성되는 버그 수정

### DIFF
--- a/src/main/java/ajou/mse/dimensionguard/controller/InGameController.java
+++ b/src/main/java/ajou/mse/dimensionguard/controller/InGameController.java
@@ -10,7 +10,6 @@ import ajou.mse.dimensionguard.service.InGameService;
 import ajou.mse.dimensionguard.service.RecordService;
 import ajou.mse.dimensionguard.service.RoomService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -70,8 +69,11 @@ public class InGameController {
         GameResult gameResult = inGameService.isGameEnded(roomId);
         if (gameResult != GameResult.NOT_END) {
             RoomDto roomDto = roomService.findDtoById(roomId);
-            recordService.record(roomDto, gameResult);
-            roomService.deleteWithPlayers(roomId);
+            // Host만 record를 생성하고 room을 삭제하도록 하여 중복 생성되는 문제 상황을 방지한다.
+            if (roomDto.getCreatedBy().equals(userPrincipal.getMemberId())) {
+                recordService.record(roomDto, gameResult);
+                roomService.deleteWithPlayers(roomId);
+            }
         }
 
         return inGameData;

--- a/src/main/java/ajou/mse/dimensionguard/service/RecordService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/RecordService.java
@@ -52,11 +52,11 @@ public class RecordService {
         return RecordDto.from(record);
     }
 
-    public RecordDto findDtoByRoomId(Long roomId) {
-        return RecordDto.from(findByRoomId(roomId));
-    }
-
     private Record findByRoomId(Long roomId) {
         return recordRepository.findByRoomId(roomId).orElseThrow(() -> new RecordNotFoundByRoomIdException(roomId));
+    }
+
+    public RecordDto findDtoByRoomId(Long roomId) {
+        return RecordDto.from(findByRoomId(roomId));
     }
 }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #52

## 🏃‍ Task
- 게임 종료 시 Record가 인원수만큼 중복 생성되는 버그 수정

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
