### PR TITLE
게임 시작 시 보스의 체력을 `히어로 인원수 * 100`으로 초기화하도록 수정

### DIFF
--- a/src/main/java/ajou/mse/dimensionguard/domain/player/Boss.java
+++ b/src/main/java/ajou/mse/dimensionguard/domain/player/Boss.java
@@ -37,8 +37,8 @@ public class Boss extends Player {
         this.numOfSkillHit = numOfSkillHit;
     }
 
-    public void initHp(int numOfPlayers) {
-        this.setHp(BOSS_DEFAULT_HP * numOfPlayers);
+    public void initHp(int numOfHeroes) {
+        this.setHp(BOSS_DEFAULT_HP * numOfHeroes);
     }
 
     public void decreaseHp(Integer damageDealt) {

--- a/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
+++ b/src/main/java/ajou/mse/dimensionguard/service/RoomService.java
@@ -106,7 +106,7 @@ public class RoomService {
         }
 
         Boss boss = getBossFromRoom(room);
-        boss.initHp(room.getPlayers().size());
+        boss.initHp(room.getPlayers().size() - 1);
     }
 
     @Transactional


### PR DESCRIPTION
## 🔥 Related Issue
- Close #50

## 🏃‍ Task
- 게임 시작 시 보스의 체력을 `히어로 인원수 * 100`으로 초기화하도록 수정

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
