### PR TITLE
Jacoco test coverage 설정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,6 +28,13 @@ jobs:
         with:
           arguments: build
 
+      - name: Upload Jacoco Report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html
+
       - name: Docker build and push
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,10 @@ jobs:
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: build
+
+      - name: Upload Jacoco Report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.4'
     id 'io.spring.dependency-management' version '1.1.3'
+    id 'jacoco'
+}
+
+jacoco {
+    toolVersion = '0.8.9'
 }
 
 group = 'com.momong'
@@ -74,4 +79,61 @@ tasks.named('test') {
 
 tasks.named('jar') {
     enabled = false
+}
+
+test {
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+
+    reports {
+        html.required.set(true)
+
+        // QueryDSL Q클래스 제외
+        def Qdomains = []
+        for (qPattern in "**/QA".."**/QZ") {
+            Qdomains.add(qPattern + "*")
+        }
+
+        afterEvaluate {
+            classDirectories.setFrom(files(classDirectories.files.collect {
+                fileTree(dir: it,
+                        excludes: [] + Qdomains,
+                        includes: [
+                                '**/service/**',
+                                '**/api/**'
+                        ])
+            }))
+        }
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+
+            includes = [
+                    '*.*Service*',
+                    '*.*Controller*'
+            ]
+        }
+    }
 }

--- a/src/test/java/com/momong/backend/unit/domain/member/service/MemberCommandServiceTest.java
+++ b/src/test/java/com/momong/backend/unit/domain/member/service/MemberCommandServiceTest.java
@@ -94,13 +94,26 @@ class MemberCommandServiceTest {
         assertThat(t).isInstanceOf(InvalidMemberNicknameException.class);
     }
 
-    @DisplayName("제한된 글자수에 맞지 않는 닉네임이 주어지고, 회원 닉네임을 수정하면, 예외가 발생한다.")
+    @DisplayName("제한된 글자수에 맞지 않는(두 글자 미만) 닉네임이 주어지고, 회원 닉네임을 수정하면, 예외가 발생한다.")
     @Test
-    void givenNicknameNotFitCharacterCountLimit_whenUpdateMemberNickname_thenThrowInvalidMemberNicknameException() {
+    void givenNicknameOfLessThanTwoCharacters_whenUpdateMemberNickname_thenThrowInvalidMemberNicknameException() {
         // given
 
         // when
         Throwable t = catchThrowable(() -> sut.updateMemberNickname(1L, "1"));
+
+        // then
+        verifyEveryMocksShouldHaveNoMoreInteractions();
+        assertThat(t).isInstanceOf(InvalidMemberNicknameException.class);
+    }
+
+    @DisplayName("제한된 글자수에 맞지 않는(12 글자 초과) 닉네임이 주어지고, 회원 닉네임을 수정하면, 예외가 발생한다.")
+    @Test
+    void givenNicknameOfGreaterThanTwoCharacters_whenUpdateMemberNickname_thenThrowInvalidMemberNicknameException() {
+        // given
+
+        // when
+        Throwable t = catchThrowable(() -> sut.updateMemberNickname(1L, "123456789012345"));
 
         // then
         verifyEveryMocksShouldHaveNoMoreInteractions();


### PR DESCRIPTION
## 🔥 Related Issue
- Close #3

## 🏃‍ Task
- 누락되었던 테스트 코드 작성
- Jacoco test coverage 설정

## 📄 Reference
- [Gredle docs - The JaCoCo Plugin](https://docs.gradle.org/current/userguide/jacoco_plugin.html)
- [Jacoco로 테스트 커버리지 확인하기](https://typo.tistory.com/327)
- [달록의 Jacoco 적용기 (feat. Gradle)](https://hudi.blog/dallog-jacoco/)
- [Jacoco를 통한 코드 커버리지 측정](https://velog.io/@bruni_23yong/%ED%85%8C%EC%8A%A4%ED%8A%B8-Jacoco%EB%A5%BC-%ED%86%B5%ED%95%9C-%EC%BD%94%EB%93%9C-%EC%BB%A4%EB%B2%84%EB%A6%AC%EC%A7%80-%EC%B8%A1%EC%A0%95#jacoco-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)
- [actions/upload-artifact 사용하여 jacoco test report upload하기](https://velog.io/@sontulip/github-actions-ci#4-html-jacoco-report%EB%A5%BC-%EC%97%85%EB%A1%9C%EB%93%9C%ED%95%9C%EB%8B%A4)
